### PR TITLE
feat: add average CPU usage and component temperature metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,9 +1081,12 @@ dependencies = [
 name = "server-monitoring"
 version = "0.1.0"
 dependencies = [
+ "dotenv",
  "rocket",
  "serde",
  "sysinfo",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "GPL-3.0"
 readme = "README.md"
 
 [dependencies]
+dotenv = "0.15.0"
 rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.36.0"
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -1,19 +1,25 @@
 use rocket::{get, launch, routes, serde::json::Json};
 use server_monitoring::{
-    ComponentInformation, CpuInformation, CpuOverview, MemoryInformation, ServerMetrics,
-    SystemInformation,
+    ComponentInformation, ComponentOverview, CpuInformation, CpuOverview, MemoryInformation,
+    ServerMetrics, SystemInformation,
 };
 use sysinfo::{Components, System};
+use tracing::{error, instrument};
+use tracing_subscriber::{filter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[get("/metrics")]
+#[instrument]
 fn index() -> Json<ServerMetrics> {
     let mut sys = System::new_all();
     sys.refresh_all();
     std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
     sys.refresh_all();
 
+    error!("warn");
+
     let cpus = sys.cpus();
     let components = Components::new_with_refreshed_list();
+
     let m = ServerMetrics {
         system: SystemInformation {
             name: System::name(),
@@ -27,31 +33,69 @@ fn index() -> Json<ServerMetrics> {
             total_swap: sys.total_swap(),
             used_swap: sys.used_swap(),
         },
-        cpus: CpuOverview {
-            total: cpus.len(),
-            arch: System::cpu_arch(),
-            cpus: cpus
-                .iter()
-                .map(|cpu| CpuInformation {
-                    name: cpu.name().to_string(),
-                    frequency: cpu.frequency(),
-                    usage: cpu.cpu_usage(),
-                })
-                .collect(),
+        cpus: {
+            let total_cpus = cpus.len() as f32;
+            let cpu_usage_sum = cpus.iter().map(|cpu| cpu.cpu_usage()).sum::<f32>();
+
+            CpuOverview {
+                total: cpus.len(),
+                arch: System::cpu_arch(),
+                average_usage: cpu_usage_sum / total_cpus,
+                cpus: cpus
+                    .iter()
+                    .map(|cpu| CpuInformation {
+                        name: cpu.name().to_string(),
+                        frequency: cpu.frequency(),
+                        usage: cpu.cpu_usage(),
+                    })
+                    .collect(),
+            }
         },
-        components: components
-            .iter()
-            .map(|component| ComponentInformation {
-                name: component.label().to_string(),
-                temperature: component.temperature(),
-            })
-            .collect(),
+        components: {
+            let component_count = components.len() as f32;
+            let component_temperature_sum = components
+                .iter()
+                .map(|component| component.temperature().unwrap_or(0.0))
+                .sum::<f32>();
+
+            ComponentOverview {
+                average_temperature: Some(component_temperature_sum / component_count),
+                components: components
+                    .iter()
+                    .map(|component| ComponentInformation {
+                        name: component.label().to_string(),
+                        temperature: component.temperature(),
+                    })
+                    .collect(),
+            }
+        },
     };
 
     Json(m)
 }
 
+#[get("/ping")]
+fn ping() {}
+
+fn init() {
+    dotenv::dotenv().ok();
+
+    let _filter =
+        filter::Targets::new().with_target("agent", tracing::metadata::LevelFilter::TRACE);
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .compact()
+                .with_ansi(false),
+        )
+        .with(filter::LevelFilter::DEBUG)
+        .init();
+}
+
 #[launch]
 fn rocket() -> _ {
-    rocket::build().mount("/", routes![index])
+    init();
+    let figment = rocket::Config::figment().merge(("port", 1111));
+    rocket::custom(figment).mount("/", routes![index, ping])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub struct ServerMetrics {
     pub system: SystemInformation,
     pub memory: MemoryInformation,
     pub cpus: CpuOverview,
-    pub components: Vec<ComponentInformation>,
+    pub components: ComponentOverview,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,6 +28,7 @@ pub struct MemoryInformation {
 pub struct CpuOverview {
     pub total: usize,
     pub arch: String,
+    pub average_usage: f32,
     pub cpus: Vec<CpuInformation>,
 }
 
@@ -36,6 +37,12 @@ pub struct CpuInformation {
     pub name: String,
     pub frequency: u64,
     pub usage: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentOverview {
+    pub average_temperature: Option<f32>,
+    pub components: Vec<ComponentInformation>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
- Replace components Vec with ComponentOverview struct including average
  temperature and detailed components list for better aggregation.
- xtend CpuOverview with average_usage field to provide overall CPU 
  ;load.
- Update metrics endpoint to calculate and return average CPU usage and
  average component temperature.
- Add tracing and dotenv dependencies; initialize tracing subscriber for
  improved logging and diagnostics.
- Prepare groundwork for enhanced observability and more comprehensive
  system monitoring data.