### PR TITLE
feat(agent): add configurable address, port, and secret auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+
+.env

--- a/src/bin/agent.rs
+++ b/src/bin/agent.rs
@@ -1,7 +1,18 @@
-use rocket::{get, launch, routes, serde::json::Json};
+use dotenv::Error;
+use rocket::{
+    Request,
+    figment::Figment,
+    get,
+    http::Status,
+    launch,
+    request::{FromRequest, Outcome},
+    routes,
+    serde::json::Json,
+};
 use server_monitoring::{
     ComponentInformation, ComponentOverview, CpuInformation, CpuOverview, MemoryInformation,
     ServerMetrics, SystemInformation,
+    util::{get_addr, get_port, get_secret},
 };
 use sysinfo::{Components, System};
 use tracing::{error, instrument};
@@ -9,7 +20,7 @@ use tracing_subscriber::{filter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[get("/metrics")]
 #[instrument]
-fn index() -> Json<ServerMetrics> {
+fn metrics(secret: SecretKey) -> Json<ServerMetrics> {
     let mut sys = System::new_all();
     sys.refresh_all();
     std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
@@ -93,9 +104,42 @@ fn init() {
         .init();
 }
 
+fn get_config() -> Figment {
+    rocket::Config::figment()
+        .merge(("port", get_port()))
+        .merge(("address", get_addr()))
+}
+
 #[launch]
 fn rocket() -> _ {
     init();
-    let figment = rocket::Config::figment().merge(("port", 1111));
-    rocket::custom(figment).mount("/", routes![index, ping])
+    let figment = get_config();
+
+    rocket::custom(figment).mount("/", routes![metrics, ping])
+}
+
+#[derive(Debug)]
+struct SecretKey;
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for SecretKey {
+    type Error = ();
+
+    async fn from_request(
+        request: &'r rocket::Request<'_>,
+    ) -> rocket::request::Outcome<Self, Self::Error> {
+        let header = request.headers().get_one("X-MONITORING-SECRET");
+        let secret = get_secret();
+        if let Some(secret) = secret {
+            if let Some(passed_secret) = header
+                && passed_secret == secret
+            {
+                Outcome::Success(SecretKey)
+            } else {
+                Outcome::Error((Status::Unauthorized, ()))
+            }
+        } else {
+            Outcome::Success(SecretKey)
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod util;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,26 @@
+use std::net::Ipv4Addr;
+
+const AGENT_PORT: &str = "AGENT_PORT";
+
+const DEFAULT_PORT: u32 = 51243;
+
+pub fn get_port() -> u32 {
+    let port_from_env = std::env::var(AGENT_PORT);
+    port_from_env.map_or(DEFAULT_PORT, |res| res.parse().unwrap_or(DEFAULT_PORT))
+}
+
+const AGENT_ADDR: &str = "AGENT_ADDR";
+
+const DEFAULT_ADDR: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
+
+pub fn get_addr() -> Ipv4Addr {
+    let addr_from_env = std::env::var(AGENT_ADDR);
+    addr_from_env.map_or(DEFAULT_ADDR, |res| res.parse().unwrap_or(DEFAULT_ADDR))
+}
+
+const AGENT_SECRET: &str = "AGENT_SECRET";
+
+pub fn get_secret() -> Option<String> {
+    let secret_from_env = std::env::var(AGENT_SECRET);
+    secret_from_env.ok()
+}


### PR DESCRIPTION
Introduce a util module to read AGENT_ADDR, AGENT_PORT, and AGENT_SECRET
from environment variables with defaults. Update Rocket server to use
these configs for binding address and port. Add request guard to enforce
optional secret authentication via X-MONITORING-SECRET header, returning
401 Unauthorized if the secret is set but not provided or mismatched.

This improves flexibility and security by allowing runtime configuration
and optional access control for the metrics endpoint.