### PR TITLE
feat(install): Update agent configuration options

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,9 @@ install -m 755 target/release/agent /usr/local/bin/guardia-agent
 cat > /etc/default/guardia-agent <<EOF
 # Environment variables for the guardia-agent
 # Example:
-# SECRET_KEY=your_secret_key
-# PORT=8080
+# AGENT_ADDR=0.0.0.0
+# AGENT_SECRET=your_secret_key
+# AGENT_PORT=51243
 EOF
 
 # Create the systemd service file


### PR DESCRIPTION
Modify the default configuration file for the guardia-agent to
include new environment variables for the agent address, secret key,
and port. This allows for more flexibility in configuring the agent
during installation.